### PR TITLE
Add issue templates into anza repo

### DIFF
--- a/.github/monorepo-triage.yaml
+++ b/.github/monorepo-triage.yaml
@@ -1,0 +1,32 @@
+name: Monorepo Triage Access Request
+description: Issue template to request Triage access to the Agave Monorepo
+title: "Request Triage access for [User] to the Agave Monorepo"
+labels: ["access"]
+assignees:
+  - joeaba
+  - CriesofCarrots
+  - t-nelson
+  - sakridge
+  - yihau
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please complete the following information to proceed with your access request,
+        make sure to update [User] with your GitHub username in the issue title:
+  - type: input
+    id: username
+    attributes:
+      label: GitHub Username
+      description: What's your GitHub Username?
+      placeholder: ex. joeaba
+    validations:
+      required: true
+  - type: input
+    id: discord_id
+    attributes:
+      label: Discord ID
+      description: What's your Discord ID? 
+      placeholder: ex. joe#1234
+    validations:
+      required: true

--- a/.github/monorepo-write.yaml
+++ b/.github/monorepo-write.yaml
@@ -1,0 +1,40 @@
+name: Monorepo Write Access Request
+description: Issue template to request Write access to the Agave Monorepo
+title: "Request Write access for [User] to the Agave Monorepo"
+labels: ["access"]
+assignees:
+  - joeaba
+  - CriesofCarrots
+  - t-nelson
+  - sakridge
+  - yihau
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please complete the following information to proceed with your access request,
+        make sure to update [User] with your GitHub username in the issue title:
+  - type: input
+    id: username
+    attributes:
+      label: GitHub Username
+      description: What's your GitHub Username?
+      placeholder: ex. joeaba
+    validations:
+      required: true
+  - type: input
+    id: discord_id
+    attributes:
+      label: Discord ID
+      description: What's your Discord ID? 
+      placeholder: ex. joe#1234
+    validations:
+      required: true
+  - type: input
+    id: previous_access_issue
+    attributes:
+      label: Previously approved Triage access request issue
+      description: Link to previously approved access request issue
+      placeholder: ex. https://github.com/anza-xyz/contributor-access-policy/issues/X
+    validations:
+      required: true  


### PR DESCRIPTION
These echo the monorepo templates in https://github.com/solana-labs/contributor-access-policy, but updated to Agave and with `mvines` removed from assignees.