### PR TITLE
replace [User] with _GITHUB_USERNAME_

### DIFF
--- a/.github/ISSUE_TEMPLATE/monorepo-triage.yaml
+++ b/.github/ISSUE_TEMPLATE/monorepo-triage.yaml
@@ -1,6 +1,6 @@
 name: Monorepo Triage Access Request
 description: Issue template to request Triage access to the Agave Monorepo
-title: "Request Triage access for [User] to the Agave Monorepo"
+title: "Request Triage access for _GITHUB_USERNAME_ to the Agave Monorepo"
 labels: ["access"]
 assignees:
   - joeaba
@@ -13,7 +13,7 @@ body:
     attributes:
       value: |
         Please complete the following information to proceed with your access request,
-        make sure to update [User] with your GitHub username in the issue title:
+        make sure to update _GITHUB_USERNAME_ with your GitHub username in the issue title:
   - type: input
     id: username
     attributes:

--- a/.github/ISSUE_TEMPLATE/monorepo-write.yaml
+++ b/.github/ISSUE_TEMPLATE/monorepo-write.yaml
@@ -1,6 +1,6 @@
 name: Monorepo Write Access Request
 description: Issue template to request Write access to the Agave Monorepo
-title: "Request Write access for [User] to the Agave Monorepo"
+title: "Request Write access for _GITHUB_USERNAME_ to the Agave Monorepo"
 labels: ["access"]
 assignees:
   - joeaba
@@ -13,7 +13,7 @@ body:
     attributes:
       value: |
         Please complete the following information to proceed with your access request,
-        make sure to update [User] with your GitHub username in the issue title:
+        make sure to update _GITHUB_USERNAME_ with your GitHub username in the issue title:
   - type: input
     id: username
     attributes:


### PR DESCRIPTION
#### Problem

It's a little bit confused that if we need to keep `[]`. sometimes I see some issues looks like:
`Request Triage access for [yihau] to the Agave Monorepo`

#### Summary of Changes

use `_GITHUB_USERNAME_` as the placeholder. it should be more easy to understand. if we see something like
`Request Triage access for _yihau_ to the Agave Monorepo` in the future. I will remove the name from the title and parse it by the body 👿